### PR TITLE
put the correct table names in the migration for the UserThemes table

### DIFF
--- a/htdocs/app/Database/Migrations/2022-09-12-181521_UserThemes.php
+++ b/htdocs/app/Database/Migrations/2022-09-12-181521_UserThemes.php
@@ -16,12 +16,12 @@ class UserThemes extends Migration
                 'auto_increment' => true,
             ],
 
-            'ClassID' => [
+            'UserID' => [
                 'type' => 'INT',
                 'constraint' => '11',
             ],
 
-            'LearningPathID' => [
+            'ThemeID' => [
                 'type' => 'INT',
                 'constraint' => '11',
             ],


### PR DESCRIPTION
changed the values of the table name, so it's correct by the erd which can be viewed in my earlier pull request as seen [here](https://github.com/Arczius/BrewingBards/pull/5)